### PR TITLE
Include lib folder when publishing the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "dependencies": {
     "prop-types": "^15.5.0"
   },
+  "files": [
+    "lib"
+  ],
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-core": "^6.24.0",


### PR DESCRIPTION
This updates the package definition to include the `lib` folder when publishing the package to `npm`.

This is currently being excluded, despite being built on `prepublish`.