### PR TITLE
Tooltip line break

### DIFF
--- a/src/components/Elements/Basic.jsx
+++ b/src/components/Elements/Basic.jsx
@@ -11,7 +11,8 @@ const Basic = ({ title, start, end, style, tooltip, classes }) =>
     <div className="rt-element__tooltip">
       {
         tooltip
-        ? <div>{tooltip}</div>
+        // eslint-disable-next-line react/no-array-index-key
+        ? tooltip.split('\n').map((partial, i) => <div key={i}>{partial.trim()}</div>)
         : (
           <div>
             <div>{title}</div>

--- a/src/components/Elements/Basic.jsx
+++ b/src/components/Elements/Basic.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { getDayMonth } from '../../utils/formatDate'
 import createClasses from '../../utils/classes'
 
-
 const Basic = ({ title, start, end, style, tooltip, classes }) =>
   <div className={createClasses('rt-element', classes)} style={style}>
     <div className="rt-element__content" aria-hidden="true">

--- a/src/components/Elements/Basic.jsx
+++ b/src/components/Elements/Basic.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { getDayMonth } from '../../utils/formatDate'
 import createClasses from '../../utils/classes'
 
+
 const Basic = ({ title, start, end, style, tooltip, classes }) =>
   <div className={createClasses('rt-element', classes)} style={style}>
     <div className="rt-element__content" aria-hidden="true">
@@ -11,8 +12,8 @@ const Basic = ({ title, start, end, style, tooltip, classes }) =>
     <div className="rt-element__tooltip">
       {
         tooltip
-        // eslint-disable-next-line react/no-array-index-key
-        ? tooltip.split('\n').map((partial, i) => <div key={i}>{partial.trim()}</div>)
+        // eslint-disable-next-line react/no-danger
+        ? <div dangerouslySetInnerHTML={{ __html: tooltip.split('\n').join('<br>') }} />
         : (
           <div>
             <div>{title}</div>

--- a/src/components/Elements/__tests__/Basic.jsx
+++ b/src/components/Elements/__tests__/Basic.jsx
@@ -20,16 +20,14 @@ describe('<Basic />', () => {
       const tooltip = 'Test tooltip'
       const props = { ...defaultProps, tooltip }
       const wrapper = shallow(<Basic {...props} />)
-      expect(getTooltip(wrapper).text()).toBe(tooltip)
+      expect(getTooltip(wrapper).html()).toMatch('Test tooltip')
     })
 
     it('handles multiline tooltips', () => {
-      const tooltip = `Test
-        tooltip`
+      const tooltip = 'Test\ntooltip'
       const props = { ...defaultProps, tooltip }
-      const expected = '<div>Test</div><div>tooltip</div>'
       const wrapper = shallow(<Basic {...props} />)
-      expect(getTooltip(wrapper).find('.rt-element__tooltip').html()).toMatch(expected)
+      expect(getTooltip(wrapper).html()).toMatch('Test<br>tooltip')
     })
 
     it('renders the title, formatted start and end date if the tooltip prop does not exist', () => {
@@ -44,7 +42,7 @@ describe('<Basic />', () => {
       expect(getTooltip(wrapper).text()).toMatch('End 15 Apr')
     })
 
-    it('can take an optional list of class names to add to the parent', () => {
+    it('can take an optional list of classnames to add to the parent', () => {
       const props = { ...defaultProps, classes: ['foo', 'bar'] }
       const wrapper = shallow(<Basic {...props} />)
       expect(wrapper.find('.rt-element').hasClass('foo')).toBe(true)

--- a/src/components/Elements/__tests__/Basic.jsx
+++ b/src/components/Elements/__tests__/Basic.jsx
@@ -23,6 +23,15 @@ describe('<Basic />', () => {
       expect(getTooltip(wrapper).text()).toBe(tooltip)
     })
 
+    it('handles multiline tooltips', () => {
+      const tooltip = `Test
+        tooltip`
+      const props = { ...defaultProps, tooltip }
+      const expected = '<div>Test</div><div>tooltip</div>'
+      const wrapper = shallow(<Basic {...props} />)
+      expect(getTooltip(wrapper).find('.rt-element__tooltip').html()).toMatch(expected)
+    })
+
     it('renders the title, formatted start and end date if the tooltip prop does not exist', () => {
       const tooltip = ''
       const title = 'TEST'

--- a/src/scss/components/_element.scss
+++ b/src/scss/components/_element.scss
@@ -21,7 +21,7 @@
   position: absolute;
   bottom: 100%;
   left: 50%;
-  z-index: 1;
+  z-index: 2;
   padding: 10px;
   line-height: 1.3;
   white-space: nowrap;


### PR DESCRIPTION
* Prevent marker line overlaying tooltips
* Allow line breaks in tooltips

![screen shot 2017-06-05 at 12 09 45](https://cloud.githubusercontent.com/assets/4982001/26781725/fca60d4e-49e7-11e7-9ca9-4f583054a6c9.png)
