### PR TITLE
Use Context to pass clickElement to Elements

### DIFF
--- a/src/components/Layout/Sticky.jsx
+++ b/src/components/Layout/Sticky.jsx
@@ -113,7 +113,7 @@ class StickyLayout extends PureComponent {
   }
 
   render() {
-    const { isOpen, tracks, now, time, timebar, toggleTrackOpen, clickElement } = this.props
+    const { isOpen, tracks, now, time, timebar, toggleTrackOpen } = this.props
     const {
       isSticky,
       headerHeight,
@@ -138,7 +138,6 @@ class StickyLayout extends PureComponent {
               time={time}
               timebar={timebar}
               tracks={tracks}
-              clickElement={clickElement}
               sticky={{
                 isSticky,
                 setHeaderHeight: this.setHeaderHeight,

--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -3,7 +3,7 @@ import Sidebar from '../Sidebar'
 import Timeline from '../Timeline'
 import propTypes from './propTypes'
 
-const Layout = ({ isOpen, tracks, now, time, timebar, toggleTrackOpen, clickElement }) => (
+const Layout = ({ isOpen, tracks, now, time, timebar, toggleTrackOpen }) => (
   <div className={`rt-layout ${isOpen ? 'rt-is-open' : ''}`}>
     <div className="rt-layout__side">
       <Sidebar
@@ -19,7 +19,6 @@ const Layout = ({ isOpen, tracks, now, time, timebar, toggleTrackOpen, clickElem
           time={time}
           timebar={timebar}
           tracks={tracks}
-          clickElement={clickElement}
         />
       </div>
     </div>

--- a/src/components/Timeline/Body.jsx
+++ b/src/components/Timeline/Body.jsx
@@ -6,11 +6,11 @@ import Grid from './Grid'
 
 class Body extends PureComponent {
   render() {
-    const { time, grid, tracks, clickElement } = this.props
+    const { time, grid, tracks } = this.props
     return (
       <div className="rt-timeline__body">
         {grid && <Grid time={time} grid={grid} />}
-        <Tracks time={time} tracks={tracks} clickElement={clickElement} />
+        <Tracks time={time} tracks={tracks} />
       </div>
     )
   }
@@ -19,8 +19,7 @@ class Body extends PureComponent {
 Body.propTypes = {
   time: PropTypes.shape({}).isRequired,
   grid: PropTypes.arrayOf(PropTypes.shape({})),
-  tracks: PropTypes.arrayOf(PropTypes.shape({})),
-  clickElement: PropTypes.func
+  tracks: PropTypes.arrayOf(PropTypes.shape({}))
 }
 
 export default Body

--- a/src/components/Timeline/Tracks/Element.jsx
+++ b/src/components/Timeline/Tracks/Element.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types'
 
 import BasicElement from '../../Elements/Basic'
 
-const Element = (props) => {
-  const { time, style, id, title, start, end, tooltip, classes, clickElement } = props
+const Element = (props, context) => {
+  const { time, style, id, title, start, end, tooltip, classes } = props
+  const { clickElement } = context
   const handleClick = () => {
     clickElement(props)
   }
@@ -40,7 +41,10 @@ Element.propTypes = {
   title: PropTypes.string,
   start: PropTypes.instanceOf(Date).isRequired,
   end: PropTypes.instanceOf(Date).isRequired,
-  tooltip: PropTypes.string,
+  tooltip: PropTypes.string
+}
+
+Element.contextTypes = {
   clickElement: PropTypes.func
 }
 

--- a/src/components/Timeline/Tracks/Track.jsx
+++ b/src/components/Timeline/Tracks/Track.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import Tracks from './'
 import Element from './Element'
 
-const Track = ({ time, elements, isOpen, tracks, clickElement }) =>
+const Track = ({ time, elements, isOpen, tracks }) =>
   <div className="tr-track">
     <div className="rt-track__elements">
       { elements.filter(({ start, end }) => (end > start)).map(element =>
@@ -12,7 +12,6 @@ const Track = ({ time, elements, isOpen, tracks, clickElement }) =>
           key={element.id}
           time={time}
           style={element.style}
-          clickElement={clickElement}
           {...element}
         />)
       }
@@ -26,8 +25,7 @@ Track.propTypes = {
   time: PropTypes.shape({}).isRequired,
   isOpen: PropTypes.bool,
   elements: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  tracks: PropTypes.arrayOf(PropTypes.shape({})),
-  clickElement: PropTypes.func
+  tracks: PropTypes.arrayOf(PropTypes.shape({}))
 }
 
 export default Track

--- a/src/components/Timeline/Tracks/__tests__/Element.jsx
+++ b/src/components/Timeline/Tracks/__tests__/Element.jsx
@@ -34,11 +34,9 @@ describe('<Element />', () => {
 
   describe('clickElement', () => {
     it('renders with a cursor pointer style if callback is passed', () => {
-      const props = {
-        ...defaultProps,
-        clickElement: jest.fn()
-      }
-      const wrapper = shallow(<Element {...props} />)
+      const props = { ...defaultProps }
+      const context = { clickElement: jest.fn() }
+      const wrapper = shallow(<Element {...props} />, { context })
       expect(wrapper.prop('style')).toMatchObject({ cursor: 'pointer' })
     })
 
@@ -49,8 +47,9 @@ describe('<Element />', () => {
 
     it('gets called with props when clicked', () => {
       const clickElement = jest.fn()
-      const props = { ...defaultProps, clickElement }
-      const wrapper = shallow(<Element {...props} />)
+      const props = { ...defaultProps }
+      const context = { clickElement }
+      const wrapper = shallow(<Element {...props} />, { context })
       expect(clickElement).toHaveBeenCalledTimes(0)
 
       wrapper.simulate('click')

--- a/src/components/Timeline/Tracks/index.jsx
+++ b/src/components/Timeline/Tracks/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import Track from './Track'
 
-const Tracks = ({ time, tracks, clickElement }) =>
+const Tracks = ({ time, tracks }) =>
   <div className="rt-tracks">
     {
       tracks.map(({ id, elements, isOpen, tracks: children }) =>
@@ -13,7 +13,6 @@ const Tracks = ({ time, tracks, clickElement }) =>
           elements={elements}
           isOpen={isOpen}
           tracks={children}
-          clickElement={clickElement}
         />
       )
     }
@@ -21,8 +20,7 @@ const Tracks = ({ time, tracks, clickElement }) =>
 
 Tracks.propTypes = {
   time: PropTypes.shape({}).isRequired,
-  tracks: PropTypes.arrayOf(PropTypes.shape({})),
-  clickElement: PropTypes.func
+  tracks: PropTypes.arrayOf(PropTypes.shape({}))
 }
 
 export default Tracks

--- a/src/components/Timeline/index.jsx
+++ b/src/components/Timeline/index.jsx
@@ -44,8 +44,7 @@ class Timeline extends Component {
       time,
       timebar,
       tracks,
-      sticky,
-      clickElement
+      sticky
     } = this.props
     const {
       pointerDate,
@@ -73,7 +72,7 @@ class Timeline extends Component {
           width={time.timelineWidth}
           sticky={sticky}
         />
-        <Body time={time} grid={grid} tracks={tracks} clickElement={clickElement} />
+        <Body time={time} grid={grid} tracks={tracks} />
       </div>
     )
   }
@@ -86,8 +85,7 @@ Timeline.propTypes = {
   }).isRequired,
   timebar: propTypeTimebar.isRequired,
   tracks: PropTypes.arrayOf(PropTypes.shape({})),
-  sticky: PropTypes.shape({}),
-  clickElement: PropTypes.func
+  sticky: PropTypes.shape({})
 }
 
 export default Timeline

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,7 +19,8 @@ const basePropTypes = {
   isOpen: PropTypes.bool,
   toggleOpen: PropTypes.func,
   zoomIn: PropTypes.func,
-  zoomOut: PropTypes.func
+  zoomOut: PropTypes.func,
+  clickElement: PropTypes.func
 }
 
 const timelinePropTypes = {
@@ -27,7 +28,6 @@ const timelinePropTypes = {
   tracks: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   now: PropTypes.instanceOf(Date),
   toggleTrackOpen: PropTypes.func,
-  clickElement: PropTypes.func,
   ...basePropTypes
 }
 
@@ -37,6 +37,11 @@ class Base extends Component {
     this.state = {
       time: createTime(props.scale)
     }
+  }
+
+  getChildContext() {
+    const { clickElement } = this.props
+    return { clickElement }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -69,6 +74,10 @@ class Base extends Component {
 
 Base.propTypes = basePropTypes
 
+Base.childContextTypes = {
+  clickElement: PropTypes.func
+}
+
 class Timeline extends Base {
   render() {
     const {
@@ -77,8 +86,7 @@ class Timeline extends Base {
       now,
       timebar,
       toggleTrackOpen,
-      scale,
-      clickElement
+      scale
     } = this.props
     return (
       <div className="rt">
@@ -91,7 +99,6 @@ class Timeline extends Base {
           toggleTrackOpen={toggleTrackOpen}
           time={this.state.time}
           isOpen={isOpen}
-          clickElement={clickElement}
         />
       </div>
     )
@@ -108,8 +115,7 @@ class StickyTimeline extends Base {
       now,
       timebar,
       toggleTrackOpen,
-      scale,
-      clickElement
+      scale
     } = this.props
     return (
       <div className="rt">
@@ -122,7 +128,6 @@ class StickyTimeline extends Base {
           toggleTrackOpen={toggleTrackOpen}
           time={this.state.time}
           isOpen={isOpen}
-          clickElement={clickElement}
         />
       </div>
     )


### PR DESCRIPTION
This changes the `Base` component to use it's `context` to pass `clickElement` through the component hierarchy to the Elements.