### PR TITLE
Change Track link to button

### DIFF
--- a/src/components/Sidebar/TrackKeys/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/TrackKey.jsx
@@ -3,9 +3,12 @@ import PropTypes from 'prop-types'
 
 import TrackKeys from './'
 
-const TrackKey = ({ track, toggleOpen }) => {
-  const { title, tracks, isOpen, link } = track
+const TrackKey = ({ track, toggleOpen }, context) => {
+  const { title, tracks, isOpen, hasButton } = track
+  const { clickTrackButton } = context
   const isExpandable = isOpen !== undefined
+  const handleClick = () => clickTrackButton(track)
+
   return (
     <li className="rt-track-key">
       <div className="rt-track-key__entry">
@@ -19,7 +22,7 @@ const TrackKey = ({ track, toggleOpen }) => {
           </button>
         }
         <span>{title}</span>
-        { link && <a className="rt-track-key__link" title="Open link" href={link}>link</a> }
+        { hasButton && clickTrackButton && <button className="rt-track-key__button" onClick={handleClick} /> }
       </div>
       { isOpen && tracks && tracks.length > 0 &&
         <TrackKeys tracks={tracks} toggleOpen={toggleOpen} />
@@ -32,9 +35,14 @@ TrackKey.propTypes = {
   track: PropTypes.shape({
     title: PropTypes.string.isRequired,
     tracks: PropTypes.arrayOf(PropTypes.shape({})),
-    isOpen: PropTypes.bool
+    isOpen: PropTypes.bool,
+    hasButton: PropTypes.bool
   }),
   toggleOpen: PropTypes.func
+}
+
+TrackKey.contextTypes = {
+  clickTrackButton: PropTypes.func
 }
 
 export default TrackKey

--- a/src/components/Sidebar/TrackKeys/__tests__/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/__tests__/TrackKey.jsx
@@ -5,10 +5,45 @@ import TrackKey from '../TrackKey'
 import TrackKeys from '../'
 
 describe('<TrackKey />', () => {
-  it('renders a link if passed', () => {
-    const track = { link: 'test-url', title: 'test-title' }
-    const wrapper = shallow(<TrackKey track={track} />)
-    expect(wrapper.find('[href="test-url"]').text()).toBe('link')
+  describe('link button', () => {
+    const getButton = node => node.find('.rt-track-key__button')
+
+    it('renders a button if "hasButton" is true and "clickTrackButton" exists', () => {
+      const track = { title: 'test', isOpen: true, hasButton: true }
+      const context = { clickTrackButton: jest.fn() }
+
+      const wrapper = shallow(<TrackKey track={track} />, { context })
+      expect(getButton(wrapper).exists()).toBe(true)
+    })
+
+    it('does not render when "hasButton" is false', () => {
+      const track = { title: 'test', isOpen: true }
+      const context = { clickTrackButton: jest.fn() }
+
+      const wrapper = shallow(<TrackKey track={track} />, { context })
+      expect(getButton(wrapper).exists()).toBe(false)
+    })
+
+    it('does not render when "clickTrackButton" does not exist', () => {
+      const track = { title: 'test', isOpen: true, hasButton: true }
+      const context = {}
+
+      const wrapper = shallow(<TrackKey track={track} />, { context })
+      expect(getButton(wrapper).exists()).toBe(false)
+    })
+
+    it('calls "clickTrackButton" with the track when clicked', () => {
+      const track = { title: 'test', isOpen: true, hasButton: true }
+      const clickTrackButton = jest.fn()
+      const context = { clickTrackButton }
+
+      const wrapper = shallow(<TrackKey track={track} />, { context })
+      const button = getButton(wrapper)
+
+      expect(clickTrackButton).not.toBeCalled()
+      button.simulate('click')
+      expect(clickTrackButton).toBeCalledWith(track)
+    })
   })
 
   describe('toggle button', () => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -20,7 +20,8 @@ const basePropTypes = {
   toggleOpen: PropTypes.func,
   zoomIn: PropTypes.func,
   zoomOut: PropTypes.func,
-  clickElement: PropTypes.func
+  clickElement: PropTypes.func,
+  clickTrackButton: PropTypes.func
 }
 
 const timelinePropTypes = {
@@ -40,8 +41,8 @@ class Base extends Component {
   }
 
   getChildContext() {
-    const { clickElement } = this.props
-    return { clickElement }
+    const { clickElement, clickTrackButton } = this.props
+    return { clickElement, clickTrackButton }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -75,7 +76,8 @@ class Base extends Component {
 Base.propTypes = basePropTypes
 
 Base.childContextTypes = {
-  clickElement: PropTypes.func
+  clickElement: PropTypes.func,
+  clickTrackButton: PropTypes.func
 }
 
 class Timeline extends Base {

--- a/src/scss/components/_track-key.scss
+++ b/src/scss/components/_track-key.scss
@@ -83,7 +83,7 @@
   background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjUiIHZpZXdCb3g9IjE2IDE1IDI0IDI1IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9IiNmZmYiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PHBhdGggZD0iTTMyIDE2djI0aC04VjE2eiIvPjxwYXRoIGQ9Ik0xNiAyNGgyNHY4SDE2eiIvPjwvZz48L3N2Zz4=');
 }
 
-.rt-track-key__link {
+.rt-track-key__button {
   position: absolute;
   top: 0;
   right: 0;
@@ -91,6 +91,7 @@
   z-index: 1;
   width: $react-timelines-track-height;
   color: transparent;
+  background: transparent;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
This changes the Track Key link to a button, that calls `clickTrackButton` from context when clicked.