### PR TITLE
Bump patch version to sync with tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timelines",
-  "version": "1.2.2",
+  "version": "1.3.1",
   "description": "React Timelines",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This bumps the patch version of the library, to match with the tags.