### PR TITLE
Revert "Fix tearing bug"

### DIFF
--- a/src/scss/components/_timeline.scss
+++ b/src/scss/components/_timeline.scss
@@ -1,5 +1,6 @@
 .rt-timeline {
   position: relative;
+  overflow: hidden;
   padding-top: $react-timelines-marker-height;
 }
 


### PR DESCRIPTION
JSainsburyPLC/react-timelines#65 fixes the over-scroll bug within the body, but introduces significant overflow problems. This reverts the #65, preferring over-scroll on momentum, to consistent visual bugs.