### PR TITLE
Add sideComponent for track keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timelines",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "React Timelines",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/Sidebar/TrackKeys/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/TrackKey.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import TrackKeys from './'
 
 const TrackKey = ({ track, toggleOpen }, context) => {
-  const { title, tracks, isOpen, hasButton } = track
+  const { title, tracks, isOpen, hasButton, sideComponent } = track
   const { clickTrackButton } = context
   const isExpandable = isOpen !== undefined
   const handleClick = () => clickTrackButton(track)
@@ -22,7 +22,8 @@ const TrackKey = ({ track, toggleOpen }, context) => {
           </button>
         }
         <span>{title}</span>
-        { hasButton && clickTrackButton && <button className="rt-track-key__button" onClick={handleClick} /> }
+        { hasButton && !sideComponent && clickTrackButton && <button className="rt-track-key__button" onClick={handleClick} /> }
+        { sideComponent && <div className="rt-track-key__side">{ React.cloneElement(sideComponent) }</div> }
       </div>
       { isOpen && tracks && tracks.length > 0 &&
         <TrackKeys tracks={tracks} toggleOpen={toggleOpen} />

--- a/src/components/Sidebar/TrackKeys/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/TrackKey.jsx
@@ -9,6 +9,9 @@ const TrackKey = ({ track, toggleOpen }, context) => {
   const isExpandable = isOpen !== undefined
   const handleClick = () => clickTrackButton(track)
 
+  const showSide = !!sideComponent
+  const showButton = !showSide && hasButton && clickTrackButton
+
   return (
     <li className="rt-track-key">
       <div className="rt-track-key__entry">
@@ -22,8 +25,8 @@ const TrackKey = ({ track, toggleOpen }, context) => {
           </button>
         }
         <span>{title}</span>
-        { hasButton && !sideComponent && clickTrackButton && <button className="rt-track-key__button" onClick={handleClick} /> }
-        { sideComponent && <div className="rt-track-key__side">{ React.cloneElement(sideComponent) }</div> }
+        { showButton && <button className="rt-track-key__button" onClick={handleClick} /> }
+        { showSide && <div className="rt-track-key__side">{ React.cloneElement(sideComponent) }</div> }
       </div>
       { isOpen && tracks && tracks.length > 0 &&
         <TrackKeys tracks={tracks} toggleOpen={toggleOpen} />

--- a/src/components/Sidebar/TrackKeys/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/TrackKey.jsx
@@ -24,8 +24,8 @@ const TrackKey = ({ track, toggleOpen }, context) => {
             { isOpen ? 'Close' : 'Open' }
           </button>
         }
-        <span>{title}</span>
-        { showButton && <button className="rt-track-key__button" onClick={handleClick} /> }
+        <span className="rt-track-key__title">{title}</span>
+        { showButton && <button className="rt-track-key__side rt-track-key__side--button" onClick={handleClick} /> }
         { showSide && <div className="rt-track-key__side">{ React.cloneElement(sideComponent) }</div> }
       </div>
       { isOpen && tracks && tracks.length > 0 &&

--- a/src/components/Sidebar/TrackKeys/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/TrackKey.jsx
@@ -7,10 +7,17 @@ const TrackKey = ({ track, toggleOpen }, context) => {
   const { title, tracks, isOpen, hasButton, sideComponent } = track
   const { clickTrackButton } = context
   const isExpandable = isOpen !== undefined
-  const handleClick = () => clickTrackButton(track)
 
-  const showSide = !!sideComponent
-  const showButton = !showSide && hasButton && clickTrackButton
+  const buildSideComponent = () => {
+    if (sideComponent) {
+      return React.cloneElement(sideComponent)
+    } else if (hasButton && clickTrackButton) {
+      const handleClick = () => clickTrackButton(track)
+      return <button className="rt-track-key__side-button" onClick={handleClick} />
+    }
+
+    return null
+  }
 
   return (
     <li className="rt-track-key">
@@ -25,8 +32,7 @@ const TrackKey = ({ track, toggleOpen }, context) => {
           </button>
         }
         <span className="rt-track-key__title">{title}</span>
-        { showButton && <button className="rt-track-key__side rt-track-key__side--button" onClick={handleClick} /> }
-        { showSide && <div className="rt-track-key__side">{ React.cloneElement(sideComponent) }</div> }
+        { buildSideComponent() }
       </div>
       { isOpen && tracks && tracks.length > 0 &&
         <TrackKeys tracks={tracks} toggleOpen={toggleOpen} />

--- a/src/components/Sidebar/TrackKeys/__tests__/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/__tests__/TrackKey.jsx
@@ -6,10 +6,11 @@ import TrackKeys from '../'
 
 describe('<TrackKey />', () => {
   describe('side component', () => {
-    const getSideComponent = node => node.find('.rt-track-key__side')
+    const sideComponent = <span className="side-component">Component</span>
+    const getSideComponent = node => node.find('.side-component')
 
     it('renders the side component if "sideComponent" exists', () => {
-      const track = { title: 'test', isOpen: true, sideComponent: <span>Component</span> }
+      const track = { title: 'test', isOpen: true, sideComponent }
       const context = { clickTrackButton: jest.fn() }
 
       const wrapper = shallow(<TrackKey track={track} />, { context })
@@ -20,7 +21,7 @@ describe('<TrackKey />', () => {
   })
 
   describe('link button', () => {
-    const getButton = node => node.find('.rt-track-key__button')
+    const getButton = node => node.find('.rt-track-key__side-button')
 
     it('renders a button if "hasButton" is true and "clickTrackButton" exists', () => {
       const track = { title: 'test', isOpen: true, hasButton: true }

--- a/src/components/Sidebar/TrackKeys/__tests__/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/__tests__/TrackKey.jsx
@@ -5,6 +5,20 @@ import TrackKey from '../TrackKey'
 import TrackKeys from '../'
 
 describe('<TrackKey />', () => {
+  describe('side component', () => {
+    const getSideComponent = node => node.find('.rt-track-key__side')
+
+    it('renders the side component if "sideComponent" exists', () => {
+      const track = { title: 'test', isOpen: true, sideComponent: <span>Component</span> }
+      const context = { clickTrackButton: jest.fn() }
+
+      const wrapper = shallow(<TrackKey track={track} />, { context })
+      const component = getSideComponent(wrapper)
+      expect(component.exists()).toBe(true)
+      expect(component.text()).toEqual('Component')
+    })
+  })
+
   describe('link button', () => {
     const getButton = node => node.find('.rt-track-key__button')
 
@@ -18,6 +32,14 @@ describe('<TrackKey />', () => {
 
     it('does not render when "hasButton" is false', () => {
       const track = { title: 'test', isOpen: true }
+      const context = { clickTrackButton: jest.fn() }
+
+      const wrapper = shallow(<TrackKey track={track} />, { context })
+      expect(getButton(wrapper).exists()).toBe(false)
+    })
+
+    it('does not render when "sideComponent" is present', () => {
+      const track = { title: 'test', isOpen: true, hasButton: true, sideComponent: <span>Component</span> }
       const context = { clickTrackButton: jest.fn() }
 
       const wrapper = shallow(<TrackKey track={track} />, { context })

--- a/src/scss/components/_track-key.scss
+++ b/src/scss/components/_track-key.scss
@@ -1,13 +1,13 @@
 .rt-track-key {}
 
 .rt-track-key__entry {
-  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
   overflow: hidden;
   height: $react-timelines-track-height + $react-timelines-border-width;
-  padding-right: $react-timelines-track-height;
   line-height: $react-timelines-track-height;
-  white-space: nowrap;
-  text-overflow: ellipsis;
   font-weight: bold;
   text-align: left;
   border-bottom: $react-timelines-border-width solid $react-timelines-sidebar-separator-color;
@@ -51,11 +51,9 @@
 .rt-track-key__toggle {
   $icon-size: 20px;
 
-  display: inline-block;
   overflow: hidden;
   width: $icon-size;
   height: $icon-size;
-  vertical-align: middle;
   margin-right: 10px;
   background: $react-timelines-button-background-color no-repeat center/10px;
   color: transparent;
@@ -63,15 +61,6 @@
   &:hover,
   &:focus {
     background-color: $react-timelines-button-background-color-hover;
-  }
-
-  &::after {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    content: ' ';
   }
 }
 
@@ -83,20 +72,15 @@
   background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjUiIHZpZXdCb3g9IjE2IDE1IDI0IDI1IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9IiNmZmYiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PHBhdGggZD0iTTMyIDE2djI0aC04VjE2eiIvPjxwYXRoIGQ9Ik0xNiAyNGgyNHY4SDE2eiIvPjwvZz48L3N2Zz4=');
 }
 
-.rt-track-key__side {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1;
+.rt-track-key__title {
+  flex: 1;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
-.rt-track-key__button {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1;
+.rt-track-key__side--button {
+  height: $react-timelines-track-height;
   width: $react-timelines-track-height;
   color: transparent;
   background: transparent;
@@ -109,11 +93,10 @@
 
   &::before {
     position: absolute;
-    top: 50%;
-    right: $react-timelines-sidebar-key-indent-width;
     width: $react-timelines-sidebar-key-icon-size;
     height: $react-timelines-sidebar-key-icon-size;
-    margin-top: -($react-timelines-sidebar-key-icon-size / 2);
+    margin-top: -$react-timelines-sidebar-key-icon-size / 2;
+    margin-left: -$react-timelines-sidebar-key-icon-size / 2;
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDQ4Mi4xMzYgNDgyLjEzNSI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTQ1NS40ODIgMTk4LjE4NEwzMjYuODMgMzI2LjgzMmMtMzUuNTM2IDM1LjU0LTkzLjExIDM1LjU0LTEyOC42NDcgMGwtNDIuODgtNDIuODg2IDQyLjg4LTQyLjg3NiA0Mi44ODQgNDIuODc2YzExLjg0NSAxMS44MjIgMzEuMDY0IDExLjg0NiA0Mi44ODYgMGwxMjguNjQ0LTEyOC42NDNjMTEuODE2LTExLjgzIDExLjgxNi0zMS4wNjYgMC00Mi45bC00Mi44OC00Mi44OGMtMTEuODIzLTExLjgxNS0zMS4wNjUtMTEuODE1LTQyLjg4OCAwbC00NS45MyA0NS45MzVjLTIxLjI5LTEyLjUzLTQ1LjQ5LTE3LjkwNS02OS40NS0xNi4yOWw3Mi41LTcyLjUyN2MzNS41MzYtMzUuNTIgOTMuMTM3LTM1LjUyIDEyOC42NDUgMGw0Mi44ODYgNDIuODg0YzM1LjUzNiAzNS41MjMgMzUuNTM2IDkzLjE0IDAgMTI4LjY2MnpNMjAxLjIwNiAzNjYuNjk4bC00NS45MDMgNDUuOWMtMTEuODQ1IDExLjg0Ni0zMS4wNjQgMTEuODE3LTQyLjg4IDBsLTQyLjg4NS00Mi44OGMtMTEuODQ1LTExLjgyMi0xMS44NDUtMzEuMDQyIDAtNDIuODg3bDEyOC42NDYtMTI4LjY0NWMxMS44Mi0xMS44MTQgMzEuMDctMTEuODE0IDQyLjg4NCAwbDQyLjg4NiA0Mi44ODYgNDIuODc2LTQyLjg4Ni00Mi44NzYtNDIuODhjLTM1LjU0LTM1LjUyMi05My4xMTMtMzUuNTIyLTEyOC42NSAwbC0xMjguNjUgMTI4LjY0Yy0zNS41MzcgMzUuNTQ2LTM1LjUzNyA5My4xNDcgMCAxMjguNjUzTDY5LjU0IDQ1NS40OGMzNS41MSAzNS41NCA5My4xMSAzNS41NCAxMjguNjQ2IDBsNzIuNDk2LTcyLjVjLTIzLjk1NiAxLjU5OC00OC4wOTItMy43ODMtNjkuNDc0LTE2LjI4MnoiLz48L3N2Zz4=');
     content: ' ';
   }

--- a/src/scss/components/_track-key.scss
+++ b/src/scss/components/_track-key.scss
@@ -79,7 +79,7 @@
   overflow: hidden;
 }
 
-.rt-track-key__side--button {
+.rt-track-key__side-button {
   height: $react-timelines-track-height;
   width: $react-timelines-track-height;
   color: transparent;

--- a/src/scss/components/_track-key.scss
+++ b/src/scss/components/_track-key.scss
@@ -83,6 +83,14 @@
   background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjUiIHZpZXdCb3g9IjE2IDE1IDI0IDI1IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxnIGZpbGw9IiNmZmYiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PHBhdGggZD0iTTMyIDE2djI0aC04VjE2eiIvPjxwYXRoIGQ9Ik0xNiAyNGgyNHY4SDE2eiIvPjwvZz48L3N2Zz4=');
 }
 
+.rt-track-key__side {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+}
+
 .rt-track-key__button {
   position: absolute;
   top: 0;


### PR DESCRIPTION
This augments the track key with a `sideComponent`, to allow custom React components to be passed into the side of track keys.

If the `sideComponent` is passed, it will take prevalence over the track button.