### PR TITLE
Allow overflow on Track Key entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-timelines",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "React Timelines",
   "main": "lib/index.js",
   "scripts": {

--- a/src/scss/components/_track-key.scss
+++ b/src/scss/components/_track-key.scss
@@ -5,7 +5,6 @@
   flex-direction: row;
   align-items: center;
 
-  overflow: hidden;
   height: $react-timelines-track-height + $react-timelines-border-width;
   line-height: $react-timelines-track-height;
   font-weight: bold;


### PR DESCRIPTION
This removes `overflow: hidden` from Track Keys, allowing overflowed content, such as tooltips.