### PR TITLE
Remove obsolete childContextTypes

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -92,11 +92,6 @@ class Timeline extends Component {
   }
 }
 
-Timeline.childContextTypes = {
-  clickElement: PropTypes.func,
-  clickTrackButton: PropTypes.func
-}
-
 Timeline.propTypes = {
   scale: PropTypes.shape({
     start: PropTypes.instanceOf(Date).isRequired,


### PR DESCRIPTION
This removes the obsolete childContextTypes from the Timeline component.