### PR TITLE
NOTICKET Remove Context

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,8 @@
     "import/named": "error",
     "import/default": "error",
     "react/require-default-props": "off",
-    "react/prefer-stateless-function": ["error", { "ignorePureComponents": true }]
+    "react/prefer-stateless-function": ["error", { "ignorePureComponents": true }],
+    "object-curly-newline": "off"
   },
   "settings": {
     "import/parser": "babel-eslint"

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "rimraf": "^2.6.1"
   },
   "peerDependencies": {
-    "react": ">=16.3",
-    "react-dom": ">=16.3"
+    "react": ">=16",
+    "react-dom": ">=16"
   },
   "jest": {
     "rootDir": "./src",

--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -130,7 +130,9 @@ class Layout extends PureComponent {
       timebar,
       toggleTrackOpen,
       sidebarWidth,
-      timelineViewportWidth
+      timelineViewportWidth,
+      clickElement,
+      clickTrackButton
     } = this.props
 
     const {
@@ -152,6 +154,7 @@ class Layout extends PureComponent {
             tracks={tracks}
             toggleTrackOpen={toggleTrackOpen}
             sticky={{ isSticky, headerHeight, sidebarWidth }}
+            clickTrackButton={clickTrackButton}
           />
         </div>
         <div className="rt-layout__main">
@@ -173,6 +176,7 @@ class Layout extends PureComponent {
                 headerHeight,
                 scrollLeft
               }}
+              clickElement={clickElement}
             />
           </div>
         </div>
@@ -192,7 +196,9 @@ Layout.propTypes = {
   scrollToNow: PropTypes.bool,
   onLayoutChange: PropTypes.func.isRequired,
   sidebarWidth: PropTypes.number,
-  timelineViewportWidth: PropTypes.number
+  timelineViewportWidth: PropTypes.number,
+  clickElement: PropTypes.func,
+  clickTrackButton: PropTypes.func
 }
 
 export default Layout

--- a/src/components/Sidebar/Body.jsx
+++ b/src/components/Sidebar/Body.jsx
@@ -3,15 +3,20 @@ import PropTypes from 'prop-types'
 
 import TrackKeys from './TrackKeys'
 
-const Body = ({ tracks, toggleTrackOpen }) => (
+const Body = ({ tracks, toggleTrackOpen, clickTrackButton }) => (
   <div className="rt-sidebar__body">
-    <TrackKeys tracks={tracks} toggleOpen={toggleTrackOpen} />
+    <TrackKeys
+      tracks={tracks}
+      toggleOpen={toggleTrackOpen}
+      clickTrackButton={clickTrackButton}
+    />
   </div>
 )
 
 Body.propTypes = {
   tracks: PropTypes.arrayOf(PropTypes.shape({})),
-  toggleTrackOpen: PropTypes.func
+  toggleTrackOpen: PropTypes.func,
+  clickTrackButton: PropTypes.func
 }
 
 export default Body

--- a/src/components/Sidebar/TrackKeys/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/TrackKey.jsx
@@ -2,9 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import TrackKeys from './'
-import ClickContext from '../../../contexts/ClickContext'
 
-export const Component = ({ track, toggleOpen, clickTrackButton }) => {
+const TrackKey = ({ track, toggleOpen, clickTrackButton }) => {
   const {
     title,
     tracks,
@@ -47,7 +46,7 @@ export const Component = ({ track, toggleOpen, clickTrackButton }) => {
   )
 }
 
-Component.propTypes = {
+TrackKey.propTypes = {
   track: PropTypes.shape({
     title: PropTypes.string.isRequired,
     tracks: PropTypes.arrayOf(PropTypes.shape({})),
@@ -58,14 +57,8 @@ Component.propTypes = {
   clickTrackButton: PropTypes.func
 }
 
-Component.defaultProps = {
+TrackKey.defaultProps = {
   clickTrackButton: undefined
 }
-
-const TrackKey = props => (
-  <ClickContext.Consumer>
-    { ({ clickTrackButton }) => <Component {...props} clickTrackButton={clickTrackButton} /> }
-  </ClickContext.Consumer>
-)
 
 export default TrackKey

--- a/src/components/Sidebar/TrackKeys/__tests__/TrackKey.jsx
+++ b/src/components/Sidebar/TrackKeys/__tests__/TrackKey.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import { Component as TrackKey } from '../TrackKey'
+import TrackKey from '../TrackKey'
 import TrackKeys from '../'
 
 describe('<TrackKey />', () => {

--- a/src/components/Sidebar/TrackKeys/index.jsx
+++ b/src/components/Sidebar/TrackKeys/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import TrackKey from './TrackKey'
 
-const TrackKeys = ({ tracks, toggleOpen }) => (
+const TrackKeys = ({ tracks, toggleOpen, clickTrackButton }) => (
   <ul className="rt-track-keys">
     {
       tracks.map(track => (
@@ -11,6 +11,7 @@ const TrackKeys = ({ tracks, toggleOpen }) => (
           key={track.id}
           track={track}
           toggleOpen={toggleOpen}
+          clickTrackButton={clickTrackButton}
         />
       ))
     }
@@ -19,7 +20,8 @@ const TrackKeys = ({ tracks, toggleOpen }) => (
 
 TrackKeys.propTypes = {
   tracks: PropTypes.arrayOf(PropTypes.shape({})),
-  toggleOpen: PropTypes.func
+  toggleOpen: PropTypes.func,
+  clickTrackButton: PropTypes.func
 }
 
 export default TrackKeys

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -4,15 +4,14 @@ import PropTypes from 'prop-types'
 import Header from './Header'
 import Body from './Body'
 
-const Sidebar = ({
-  timebar,
-  tracks,
-  toggleTrackOpen,
-  sticky
-}) => (
+const Sidebar = ({ timebar, tracks, toggleTrackOpen, sticky, clickTrackButton }) => (
   <div className="rt-sidebar">
     <Header timebar={timebar} sticky={sticky} />
-    <Body tracks={tracks} toggleTrackOpen={toggleTrackOpen} />
+    <Body
+      tracks={tracks}
+      toggleTrackOpen={toggleTrackOpen}
+      clickTrackButton={clickTrackButton}
+    />
   </div>
 )
 
@@ -23,7 +22,8 @@ Sidebar.propTypes = {
   }).isRequired).isRequired,
   tracks: PropTypes.arrayOf(PropTypes.shape({})),
   toggleTrackOpen: PropTypes.func,
-  sticky: PropTypes.shape({})
+  sticky: PropTypes.shape({}),
+  clickTrackButton: PropTypes.func
 }
 
 export default Sidebar

--- a/src/components/Timeline/Body.jsx
+++ b/src/components/Timeline/Body.jsx
@@ -1,25 +1,25 @@
-import React, { PureComponent } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
 import Tracks from './Tracks'
 import Grid from './Grid'
 
-class Body extends PureComponent {
-  render() {
-    const { time, grid, tracks } = this.props
-    return (
-      <div className="rt-timeline__body">
-        {grid && <Grid time={time} grid={grid} />}
-        <Tracks time={time} tracks={tracks} />
-      </div>
-    )
-  }
-}
+const Body = ({ time, grid, tracks, clickElement }) => (
+  <div className="rt-timeline__body">
+    { grid && <Grid time={time} grid={grid} /> }
+    <Tracks
+      time={time}
+      tracks={tracks}
+      clickElement={clickElement}
+    />
+  </div>
+)
 
 Body.propTypes = {
   time: PropTypes.shape({}).isRequired,
   grid: PropTypes.arrayOf(PropTypes.shape({})),
-  tracks: PropTypes.arrayOf(PropTypes.shape({}))
+  tracks: PropTypes.arrayOf(PropTypes.shape({})),
+  clickElement: PropTypes.func
 }
 
 export default Body

--- a/src/components/Timeline/Tracks/Element.jsx
+++ b/src/components/Timeline/Tracks/Element.jsx
@@ -1,38 +1,29 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events jsx-a11y/no-static-element-interactions */
-
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 import React from 'react'
 import PropTypes from 'prop-types'
 
 import BasicElement from '../../Elements/Basic'
-import ClickContext from '../../../contexts/ClickContext'
 
-export const Component = (props) => {
-  const {
-    time, style, id, title, start, end, classes, dataSet, tooltip, clickElement
-  } = props
-  const handleClick = () => {
-    clickElement(props)
-  }
+const Element = (props) => {
+  const { time, style, title, start, end, classes, dataSet, tooltip, clickElement } = props
+
+  const handleClick = () => { clickElement(props) }
   const elementStyle = {
     ...time.toStyleLeftAndWidth(start, end),
     ...clickElement ? { cursor: 'pointer' } : {}
   }
-  const clickProps = (clickElement && handleClick) ? {
-    onClick: handleClick,
-    role: 'button'
-  } : {}
+
   return (
     <div
-      key={id}
       className="rt-track__element"
       style={elementStyle}
-      {...clickProps}
+      onClick={(clickElement && handleClick) && handleClick}
     >
       <BasicElement
         title={title}
         start={start}
         end={end}
-        style={{ ...style }}
+        style={style}
         classes={classes}
         dataSet={dataSet}
         tooltip={tooltip}
@@ -41,12 +32,11 @@ export const Component = (props) => {
   )
 }
 
-Component.propTypes = {
+Element.propTypes = {
   time: PropTypes.shape({}).isRequired,
   style: PropTypes.shape({}),
   classes: PropTypes.arrayOf(PropTypes.string.isRequired),
   dataSet: PropTypes.shape({}),
-  id: PropTypes.string.isRequired,
   title: PropTypes.string,
   start: PropTypes.instanceOf(Date).isRequired,
   end: PropTypes.instanceOf(Date).isRequired,
@@ -54,14 +44,8 @@ Component.propTypes = {
   clickElement: PropTypes.func
 }
 
-Component.defaultTypes = {
+Element.defaultTypes = {
   clickElement: undefined
 }
-
-const Element = props => (
-  <ClickContext.Consumer>
-    { ({ clickElement }) => <Element {...props} clickElement={clickElement} /> }
-  </ClickContext.Consumer>
-)
 
 export default Element

--- a/src/components/Timeline/Tracks/Track.jsx
+++ b/src/components/Timeline/Tracks/Track.jsx
@@ -4,24 +4,26 @@ import PropTypes from 'prop-types'
 import Tracks from './'
 import Element from './Element'
 
-const Track = ({
-  time, elements, isOpen, tracks
-}) => (
+const Track = ({ time, elements, isOpen, tracks, clickElement }) => (
   <div className="tr-track">
     <div className="rt-track__elements">
-      { elements.filter(({ start, end }) => (end > start)).map(element =>
-        (<Element
-          key={element.id}
-          time={time}
-          style={element.style}
-          dataSet={element.dataSet}
-          {...element}
-        />))
+      {
+        elements
+          .filter(({ start, end }) => (end > start))
+          .map(element => (
+            <Element
+              key={element.id}
+              time={time}
+              clickElement={clickElement}
+              {...element}
+            />
+          ))
       }
     </div>
     {
-      isOpen && tracks && tracks.length > 0
-      && <Tracks time={time} tracks={tracks} />
+      isOpen && tracks && tracks.length > 0 && (
+        <Tracks time={time} tracks={tracks} />
+      )
     }
   </div>
 )
@@ -30,7 +32,12 @@ Track.propTypes = {
   time: PropTypes.shape({}).isRequired,
   isOpen: PropTypes.bool,
   elements: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  tracks: PropTypes.arrayOf(PropTypes.shape({}))
+  tracks: PropTypes.arrayOf(PropTypes.shape({})),
+  clickElement: PropTypes.func
+}
+
+Track.defaultProps = {
+  clickElement: undefined
 }
 
 export default Track

--- a/src/components/Timeline/Tracks/__tests__/Element.jsx
+++ b/src/components/Timeline/Tracks/__tests__/Element.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import { Component as Element } from '../Element'
+import Element from '../Element'
 import BasicElement from '../../../Elements/Basic'
 import createTime from '../../../../utils/time'
 

--- a/src/components/Timeline/Tracks/index.jsx
+++ b/src/components/Timeline/Tracks/index.jsx
@@ -3,21 +3,17 @@ import PropTypes from 'prop-types'
 
 import Track from './Track'
 
-const Tracks = ({ time, tracks }) => (
+const Tracks = ({ time, tracks, clickElement }) => (
   <div className="rt-tracks">
     {
-      tracks.map(({
-        id,
-        elements,
-        isOpen,
-        tracks: children
-      }) => (
+      tracks.map(({ id, elements, isOpen, tracks: children }) => (
         <Track
           key={id}
           time={time}
           elements={elements}
           isOpen={isOpen}
           tracks={children}
+          clickElement={clickElement}
         />
       ))
     }
@@ -26,7 +22,8 @@ const Tracks = ({ time, tracks }) => (
 
 Tracks.propTypes = {
   time: PropTypes.shape({}).isRequired,
-  tracks: PropTypes.arrayOf(PropTypes.shape({}))
+  tracks: PropTypes.arrayOf(PropTypes.shape({})),
+  clickElement: PropTypes.func
 }
 
 export default Tracks

--- a/src/components/Timeline/index.jsx
+++ b/src/components/Timeline/index.jsx
@@ -37,7 +37,8 @@ class Timeline extends Component {
       time,
       timebar,
       tracks,
-      sticky
+      sticky,
+      clickElement
     } = this.props
 
     const {
@@ -72,6 +73,7 @@ class Timeline extends Component {
           time={time}
           grid={grid}
           tracks={tracks}
+          clickElement={clickElement}
         />
       </div>
     )
@@ -88,7 +90,8 @@ Timeline.propTypes = {
     title: PropTypes.string
   }).isRequired).isRequired,
   tracks: PropTypes.arrayOf(PropTypes.shape({})),
-  sticky: PropTypes.shape({})
+  sticky: PropTypes.shape({}),
+  clickElement: PropTypes.func
 }
 
 export default Timeline

--- a/src/contexts/ClickContext.js
+++ b/src/contexts/ClickContext.js
@@ -1,5 +1,0 @@
-import React from 'react'
-
-const ClickContext = React.createContext()
-
-export default ClickContext

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types'
 import Controls from './components/Controls'
 import Layout from './components/Layout'
 import createTime from './utils/time'
-import ClickContext from './contexts/ClickContext'
 
 const UNKNOWN_WIDTH = -1
 
@@ -62,32 +61,32 @@ class Timeline extends Component {
     const { clickElement, clickTrackButton } = this.props
 
     return (
-      <ClickContext.Provider value={{ clickElement, clickTrackButton }}>
-        <div className="rt">
-          <Controls
-            isOpen={isOpen}
-            toggleOpen={toggleOpen}
-            zoomIn={zoomIn}
-            zoomOut={zoomOut}
-            zoom={zoom}
-            zoomMin={zoomMin}
-            zoomMax={zoomMax}
-          />
-          <Layout
-            enableSticky={enableSticky}
-            now={now}
-            tracks={tracks}
-            timebar={timebar}
-            toggleTrackOpen={toggleTrackOpen}
-            scrollToNow={scrollToNow}
-            time={time}
-            isOpen={isOpen}
-            onLayoutChange={this.handleLayoutChange}
-            timelineViewportWidth={timelineViewportWidth}
-            sidebarWidth={sidebarWidth}
-          />
-        </div>
-      </ClickContext.Provider>
+      <div className="rt">
+        <Controls
+          isOpen={isOpen}
+          toggleOpen={toggleOpen}
+          zoomIn={zoomIn}
+          zoomOut={zoomOut}
+          zoom={zoom}
+          zoomMin={zoomMin}
+          zoomMax={zoomMax}
+        />
+        <Layout
+          enableSticky={enableSticky}
+          now={now}
+          tracks={tracks}
+          timebar={timebar}
+          toggleTrackOpen={toggleTrackOpen}
+          scrollToNow={scrollToNow}
+          time={time}
+          isOpen={isOpen}
+          onLayoutChange={this.handleLayoutChange}
+          timelineViewportWidth={timelineViewportWidth}
+          sidebarWidth={sidebarWidth}
+          clickElement={clickElement}
+          clickTrackButton={clickTrackButton}
+        />
+      </div>
     )
   }
 }


### PR DESCRIPTION
This removes `React.createContext` and context usage from the library, due to fatal performance impacts.