### PR TITLE
Re send `clickElement` for sub-tracks

### DIFF
--- a/src/components/Timeline/Tracks/Track.jsx
+++ b/src/components/Timeline/Tracks/Track.jsx
@@ -22,7 +22,7 @@ const Track = ({ time, elements, isOpen, tracks, clickElement }) => (
     </div>
     {
       isOpen && tracks && tracks.length > 0 && (
-        <Tracks time={time} tracks={tracks} />
+        <Tracks time={time} tracks={tracks} clickElement={clickElement} />
       )
     }
   </div>


### PR DESCRIPTION
When sub tracks are rendered `clickElement` is not passed along causing
them to lose the ability to be notified when somebody clicks the
element.